### PR TITLE
Add IterKeys() helpers: IterKeysString() and IterKeysStringSorted()  (+ tests)

### DIFF
--- a/adb_helpers.go
+++ b/adb_helpers.go
@@ -1,0 +1,47 @@
+package tokyocabinet
+
+import (
+	"sort"
+)
+
+// IterKeysString is an IterKeys() helper method that returns a slice of iterated strings.
+//
+// NOTE: returned []string can be in arbitrary order, see IterKeysStringSorted()
+func (db *ADB) IterKeysString() ([]string, error) {
+	s := make([]string, 0)
+
+	c, e := db.IterKeys()
+	for {
+		if c == nil && e == nil {
+			break
+		}
+		select {
+		case err, ok := <-e:
+			if ok == false {
+				e = nil
+			} else {
+				return nil, err
+			}
+		case val, ok := <-c:
+			if ok == false {
+				c = nil
+			} else {
+				s = append(s, string(val))
+			}
+		}
+	}
+
+	return s, nil
+}
+
+// IterKeysStringSorted is an IterKeys() helper method that returns a sorted slice of iterated strings.
+func (db *ADB) IterKeysStringSorted() ([]string, error) {
+	s, err := db.IterKeysString()
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(s)
+
+	return s, nil
+}


### PR DESCRIPTION
  * The IterKeys() function signature: func (db \*ADB) IterKeys() (c chan []byte, e chan error)
      is a bit unwieldy to use with how error is returned via channel.  This helper function
      eases the pain a bit by making it more sensible for iterating over strings.  More IterKeys\*
      helpers can be added when the need presents itself.
  * I am not sure why 'e chan error' was done that way, as it seems it could have been returned
      directly as:  (c chan []byte, error)
      Since I didn't write it, and to preserve backwards compatibility, I will leave it alone (for now).
      However, in the future, it is a target for API breakage.